### PR TITLE
Fix GitHub Pages deployment: static export + workflow permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- **Fix static export compatibility**: remove `runtime = 'edge'` from `og/fetch` and delete orphaned `og/fetch` / `og/proxy` API routes that are incompatible with `output: export`
- **Fix workflow permissions**: add `permissions: contents: write` to `deploy.yml` so `GITHUB_TOKEN` can push to the `gh-pages` branch (GitHub's default token is read-only since 2023)

## Changes

| File | Change |
|---|---|
| `src/app/api/og/fetch/route.ts` | Deleted — runtime fetch incompatible with static export |
| `src/app/api/og/proxy/route.ts` | Deleted — runtime fetch incompatible with static export |
| `.github/workflows/deploy.yml` | Added `permissions: contents: write` |

## Test plan

- [ ] `npm run build` completes without errors
- [ ] GitHub Actions deploy workflow pushes to `gh-pages` without 403
- [ ] Site loads correctly on `https://edwinpuertas.github.io`

https://claude.ai/code/session_01G5Y4cU9PzjnZbLM1jSMLrB

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5Y4cU9PzjnZbLM1jSMLrB)_